### PR TITLE
Add common callbacks, imports, and setup convention to main.lua

### DIFF
--- a/source/main.lua
+++ b/source/main.lua
@@ -8,6 +8,7 @@ local gfx = playdate.graphics
 gfx.setColor(gfx.kColorBlack)
 
 function playdate.update()
+    -- Example code. Draw a full-screen rectangle and the frames per second
     gfx.fillRect(0, 0, 400, 240)
     playdate.drawFPS(0,0)
 end

--- a/source/main.lua
+++ b/source/main.lua
@@ -1,3 +1,6 @@
+-- CoreLibs imports
+import "CoreLibs/timer"
+
 import "button"
 import "crank"
 import "lifecycle"
@@ -16,4 +19,9 @@ function playdate.update()
     -- is generally what you want, if you're using sprites.
     -- See https://sdk.play.date/1.9.1/#f-graphics.sprite.update for more info
     gfx.sprite.update()
+
+    -- Update all timers once per frame. This is required if you're using
+    -- timers in your game.
+    -- See https://sdk.play.date/1.9.1/#f-timer.updateTimers for more info
+    playdate.timer.updateTimers()
 end

--- a/source/main.lua
+++ b/source/main.lua
@@ -13,8 +13,20 @@ import "simulator"
 -- Use common shorthands for playdate code
 local gfx <const> = playdate.graphics
 
-gfx.setColor(gfx.kColorBlack)
+-- By convention, most games need to perform some initial setup when they're
+-- initially launched. Perform that setup here.
+--
+-- Note: This will be called exactly once. If you're looking to do something
+-- whenever the game is resumed from the background, see playdate.gameWillResume
+-- in lifecycle.lua
+function gameDidLaunch()
+    print(playdate.metadata.name .. " launched!")
 
+    gfx.setBackgroundColor(gfx.kColorBlack)
+end
+gameDidLaunch()
+
+-- This update method is called once per frame.
 function playdate.update()
     -- Example code. Draw a full-screen rectangle and the frames per second
     gfx.fillRect(0, 0, 400, 240)

--- a/source/main.lua
+++ b/source/main.lua
@@ -11,4 +11,9 @@ function playdate.update()
     -- Example code. Draw a full-screen rectangle and the frames per second
     gfx.fillRect(0, 0, 400, 240)
     playdate.drawFPS(0,0)
+
+    -- Update and draw all sprites. Calling this method in playdate.update
+    -- is generally what you want, if you're using sprites.
+    -- See https://sdk.play.date/1.9.1/#f-graphics.sprite.update for more info
+    gfx.sprite.update()
 end

--- a/source/main.lua
+++ b/source/main.lua
@@ -1,6 +1,10 @@
--- CoreLibs imports
+-- Common CoreLibs imports.
+import "CoreLibs/object"
+import "CoreLibs/graphics"
+import "CoreLibs/sprites"
 import "CoreLibs/timer"
 
+-- Project imports
 import "button"
 import "crank"
 import "lifecycle"

--- a/source/main.lua
+++ b/source/main.lua
@@ -6,7 +6,8 @@ import "crank"
 import "lifecycle"
 import "simulator"
 
-local gfx = playdate.graphics
+-- Use common shorthands for playdate code
+local gfx <const> = playdate.graphics
 
 gfx.setColor(gfx.kColorBlack)
 


### PR DESCRIPTION
I've discovered some things are super common in developing these games, and incorporated them into the main template. They are:

- Importing the "common" CoreLibs: object, graphics, sprites, and timer
- Making the `gfx` shorthand constant
- Using a setup method for one-time code, called `gameDidLaunch`
- Calling `playdate.graphics.sprite.update()` and `playdate.timer.updateTimers()` from `playdate.update`.
- Generally adding comments throughout