### PR TITLE
Add VSCode support

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make build"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,9 +4,24 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build",
+            "label": "Build and run",
             "type": "shell",
             "command": "make build"
-        }
+        },
+        {
+            "label": "Run",
+            "type": "shell",
+            "command": "make run"
+        },
+        {
+            "label": "Compile",
+            "type": "shell",
+            "command": "make compile"
+        },
+        {
+            "label": "Clean",
+            "type": "shell",
+            "command": "make clean"
+        },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,24 +4,32 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Build and run",
+            "label": "Build and Run",
             "type": "shell",
-            "command": "make build"
+            "command": "make build",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         },
         {
             "label": "Run",
             "type": "shell",
-            "command": "make run"
+            "command": "make run",
+            "problemMatcher": []
         },
         {
             "label": "Compile",
             "type": "shell",
-            "command": "make compile"
+            "command": "make compile",
+            "problemMatcher": []
         },
         {
             "label": "Clean",
             "type": "shell",
-            "command": "make clean"
+            "command": "make clean",
+            "problemMatcher": []
         },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,7 @@
                 "owner": "lua",
                 "fileLocation": ["relative", "${workspaceFolder}"],
                 "pattern": {
-                    // error: Source/main.lua:14: '>' expected near 'st'
+                    // Example: error: Source/main.lua:14: '>' expected near 'st'
                     "regexp": "^(warning|error): (.*):(\\d+):\\s+(.*)$",
                     "severity": 1,
                     "file": 2,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,18 @@
             "label": "Build and Run",
             "type": "shell",
             "command": "make build",
-            "problemMatcher": [],
+            "problemMatcher": {
+                "owner": "lua",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": {
+                    // error: Source/main.lua:14: '>' expected near 'st'
+                    "regexp": "^(warning|error): (.*):(\\d+):\\s+(.*)$",
+                    "severity": 1,
+                    "file": 2,
+                    "line": 3,
+                    "message": 4
+                }
+            },
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,7 +34,17 @@
             "label": "Compile",
             "type": "shell",
             "command": "make compile",
-            "problemMatcher": []
+            "problemMatcher": {
+                "owner": "lua",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": {
+                    "regexp": "^(warning|error): (.*):(\\d+):\\s+(.*)$",
+                    "severity": 1,
+                    "file": 2,
+                    "line": 3,
+                    "message": 4
+                }
+            },
         },
         {
             "label": "Clean",


### PR DESCRIPTION
This adds tasks to make building in VSCode easier. These map 1:1 with the tasks in the makefile. Bring up the command panel with Command+Shift+P and type "run task"

<img width="632" alt="CleanShot 2022-03-13 at 16 44 21@2x" src="https://user-images.githubusercontent.com/547866/158084496-0ccb6354-a1ce-4e6a-b1e4-7913da09f834.png">

You can then select
- Build and Run
- Compile
- Clean
- Run

The first is also the default build task, which can also be run with Command+Shift+B

Errors found during Build and Run and Compile tasks will show up in the Problems tab.
 