### PR TITLE
Upgrade to doc comments, and add linting support

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,10 @@
+std = {
+    globals = {
+        "playdate"
+    },
+    read_globals = {
+        "import",
+        "print",
+        "string"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "Lua.diagnostics.globals": [
+        "import",
+        "playdate"
+    ]
+}

--- a/source/button.lua
+++ b/source/button.lua
@@ -7,17 +7,17 @@ local prefix = "[Button] "
 -- A Button
 --
 
--- Called immediately when the user presses the "A" button.
+--- Called immediately when the user presses the "A" button.
 function playdate.AButtonDown()
 	print(prefix .. "A button pressed down.")
 end
 
--- Called after the "A" button is held for one second.
+--- Called after the "A" button is held for one second.
 function playdate.AButtonHeld()
 	print(prefix .. "A button held down for one second.")
 end
 
--- Called immediately after the user releases the "A" button
+--- Called immediately after the user releases the "A" button
 function playdate.AButtonUp()
 	print(prefix .. "A button released.")
 end
@@ -26,61 +26,61 @@ end
 -- B Button
 --
 
--- Called immediately when the user presses the "B" button.
+--- Called immediately when the user presses the "B" button.
 function playdate.BButtonDown()
 	print(prefix .. "B button pressed down.")
 end
 
--- Called after the "B" button is held for one second.
+--- Called after the "B" button is held for one second.
 function playdate.BButtonHeld()
 	print(prefix .. "B button held down for one second.")
 end
 
--- Called immediately after the user releases the "B" button
+--- Called immediately after the user releases the "B" button
 function playdate.BButtonUp()
 	print(prefix .. "B button released.")
 end
 
 --
 -- D-pad buttons
--- 
+--
 
--- Called immediately after the player presses the down direction on the d-pad.
+--- Called immediately after the player presses the down direction on the d-pad.
 function playdate.downButtonDown()
 	print(prefix .. "Down button pressed.")
 end
 
--- Called immediately after the player releases the down direction on the d-pad.
+--- Called immediately after the player releases the down direction on the d-pad.
 function playdate.downButtonUp()
 	print(prefix .. "Down button released.")
 end
 
--- Called immediately after the player presses the left direction on the d-pad.
+--- Called immediately after the player presses the left direction on the d-pad.
 function playdate.leftButtonDown()
 	print(prefix .. "Left button pressed.")
 end
 
--- Called immediately after the player releases the left direction on the d-pad.
+--- Called immediately after the player releases the left direction on the d-pad.
 function playdate.leftButtonUp()
 	print(prefix .. "Left button released.")
 end
 
--- Called immediately after the player presses the right direction on the d-pad.
+--- Called immediately after the player presses the right direction on the d-pad.
 function playdate.rightButtonDown()
 	print(prefix .. "Right button pressed.")
 end
 
--- Called immediately after the player releases the right direction on the d-pad.
+--- Called immediately after the player releases the right direction on the d-pad.
 function playdate.rightButtonUp()
 	print(prefix .. "Right button released.")
 end
 
--- Called immediately after the player presses the up direction on the d-pad.
+--- Called immediately after the player presses the up direction on the d-pad.
 function playdate.upButtonDown()
 	print(prefix .. "Up button pressed.")
 end
 
--- Called immediately after the player releases the up direction on the d-pad.
+--- Called immediately after the player releases the up direction on the d-pad.
 function playdate.upButtonUp()
 	print(prefix .. "Up button released.")
 end

--- a/source/button.lua
+++ b/source/button.lua
@@ -1,66 +1,86 @@
--- All the callbacks for button presses. 
--- See https://sdk.play.date/1.9.0/Inside%20Playdate.html#buttonCallbacks for more information
+-- All the callbacks for button presses.
+-- See https://sdk.play.date/1.9.1/Inside%20Playdate.html#buttonCallbacks for more information
 
 local prefix = "[Button] "
 
--- A button
+--
+-- A Button
+--
+
+-- Called immediately when the user presses the "A" button.
 function playdate.AButtonDown()
 	print(prefix .. "A button pressed down.")
 end
 
+-- Called after the "A" button is held for one second.
 function playdate.AButtonHeld()
 	print(prefix .. "A button held down for one second.")
 end
 
+-- Called immediately after the user releases the "A" button
 function playdate.AButtonUp()
 	print(prefix .. "A button released.")
 end
 
--- B button
+--
+-- B Button
+--
+
+-- Called immediately when the user presses the "B" button.
 function playdate.BButtonDown()
 	print(prefix .. "B button pressed down.")
 end
 
+-- Called after the "B" button is held for one second.
 function playdate.BButtonHeld()
 	print(prefix .. "B button held down for one second.")
 end
 
+-- Called immediately after the user releases the "B" button
 function playdate.BButtonUp()
 	print(prefix .. "B button released.")
 end
 
+--
 -- D-pad buttons
+-- 
+
+-- Called immediately after the player presses the down direction on the d-pad.
 function playdate.downButtonDown()
 	print(prefix .. "Down button pressed.")
 end
 
+-- Called immediately after the player releases the down direction on the d-pad.
 function playdate.downButtonUp()
 	print(prefix .. "Down button released.")
 end
 
-
+-- Called immediately after the player presses the left direction on the d-pad.
 function playdate.leftButtonDown()
 	print(prefix .. "Left button pressed.")
 end
 
+-- Called immediately after the player releases the left direction on the d-pad.
 function playdate.leftButtonUp()
 	print(prefix .. "Left button released.")
 end
 
-
+-- Called immediately after the player presses the right direction on the d-pad.
 function playdate.rightButtonDown()
 	print(prefix .. "Right button pressed.")
 end
 
+-- Called immediately after the player releases the right direction on the d-pad.
 function playdate.rightButtonUp()
 	print(prefix .. "Right button released.")
 end
 
-
+-- Called immediately after the player presses the up direction on the d-pad.
 function playdate.upButtonDown()
 	print(prefix .. "Up button pressed.")
 end
 
+-- Called immediately after the player releases the up direction on the d-pad.
 function playdate.upButtonUp()
 	print(prefix .. "Up button released.")
 end

--- a/source/button.lua
+++ b/source/button.lua
@@ -1,7 +1,7 @@
 -- All the callbacks for button presses.
 -- See https://sdk.play.date/1.9.1/Inside%20Playdate.html#buttonCallbacks for more information
 
-local prefix = "[Button] "
+local prefix <const> = "[Button] "
 
 --
 -- A Button

--- a/source/crank.lua
+++ b/source/crank.lua
@@ -1,16 +1,21 @@
 -- All the callbacks for the crank.
--- See https://sdk.play.date/1.9.0/Inside%20Playdate.html#_crank_callbacks for more information
+-- See https://sdk.play.date/1.9.1/Inside%20Playdate.html#_crank_callbacks for more information
 
 local prefix = "[Crank] "
 
+--- Called when the crank moves.
+--- @param change number How much the crank moved, in degrees. Negative values are anti-clockwise.
+--- @param acceleratedChange number How much the crank moved, scaled by how fast it was moved.
 function playdate.cranked(change, acceleratedChange)
 	print(prefix .. string.format("Crank rotated %.4f degrees clockwise (%.4f degrees accelerated).", change, acceleratedChange))
 end
 
+--- Called when the crank is docked.
 function playdate.crankDocked()
 	print(prefix .. "Crank docked.")
 end
 
+--- Called when the crank is undocked.
 function playdate.crankUndocked()
 	print(prefix .. "Crank undocked.")
 end

--- a/source/crank.lua
+++ b/source/crank.lua
@@ -7,7 +7,12 @@ local prefix = "[Crank] "
 --- @param change number How much the crank moved, in degrees. Negative values are anti-clockwise.
 --- @param acceleratedChange number How much the crank moved, scaled by how fast it was moved.
 function playdate.cranked(change, acceleratedChange)
-	print(prefix .. string.format("Crank rotated %.4f degrees clockwise (%.4f degrees accelerated).", change, acceleratedChange))
+	local log = string.format(
+		"Crank rotated %.4f degrees clockwise (%.4f degrees accelerated).",
+		change,
+		acceleratedChange
+	)
+	print(prefix .. log)
 end
 
 --- Called when the crank is docked.

--- a/source/crank.lua
+++ b/source/crank.lua
@@ -1,7 +1,7 @@
 -- All the callbacks for the crank.
 -- See https://sdk.play.date/1.9.1/Inside%20Playdate.html#_crank_callbacks for more information
 
-local prefix = "[Crank] "
+local prefix <const> = "[Crank] "
 
 --- Called when the crank moves.
 --- @param change number How much the crank moved, in degrees. Negative values are anti-clockwise.

--- a/source/lifecycle.lua
+++ b/source/lifecycle.lua
@@ -1,7 +1,7 @@
 -- All callbacks for the app and game lifecycle.
 -- See https://sdk.play.date/1.9.1/Inside%20Playdate.html#game-lifecycle for more information
 
-local prefix = "[Lifecycle] "
+local prefix <const> = "[Lifecycle] "
 
 --
 -- System lifecycle callbacks

--- a/source/lifecycle.lua
+++ b/source/lifecycle.lua
@@ -1,29 +1,43 @@
--- All callbacks for the app and game lifecycle 
--- See https://sdk.play.date/1.9.0/Inside%20Playdate.html#game-lifecycle for more information
+-- All callbacks for the app and game lifecycle.
+-- See https://sdk.play.date/1.9.1/Inside%20Playdate.html#game-lifecycle for more information
 
 local prefix = "[Lifecycle] "
 
+--
+-- System lifecycle callbacks
+--
+
+--- Called before the system pauses the game.
+--- This is a good time to update the [menu image](https://sdk.play.date/1.9.1/Inside%20Playdate.html#f-setMenuImage).
 function playdate.gameWillPause()
 	print(prefix .. "Game will pause...")
 end
 
+--- Called before the system resumes the game.
 function playdate.gameWillResume()
 	print(prefix .. "Game will resume...")
 end
 
+--- Called when the player chooses to exit the game via the System Menu or Menu button.
 function playdate.gameWillTerminate()
 	print(prefix .. "Game will terminate...")
 end
 
+--
+-- Device callbacks
+--
 
+--- Called when the device is unlocked, if your game is running.
 function playdate.deviceDidUnlock()
 	print(prefix .. "Device did unlock.")
 end
 
+--- Called when the device is locked, if your game is running.
 function playdate.deviceWillLock()
 	print(prefix .. "Device will lock...")
 end
 
+--- Called before the device goes to low-power sleep mode because of a low battery.
 function playdate.deviceWillSleep()
 	print(prefix .. "Device will sleep...")
 end

--- a/source/main.lua
+++ b/source/main.lua
@@ -13,12 +13,12 @@ import "simulator"
 -- Use common shorthands for playdate code
 local gfx <const> = playdate.graphics
 
--- By convention, most games need to perform some initial setup when they're
--- initially launched. Perform that setup here.
---
--- Note: This will be called exactly once. If you're looking to do something
--- whenever the game is resumed from the background, see playdate.gameWillResume
--- in lifecycle.lua
+--- By convention, most games need to perform some initial setup when they're
+--- initially launched. Perform that setup here.
+---
+--- Note: This will be called exactly once. If you're looking to do something
+--- whenever the game is resumed from the background, see playdate.gameWillResume
+--- in lifecycle.lua
 local function gameDidLaunch()
     print(playdate.metadata.name .. " launched!")
 
@@ -26,7 +26,7 @@ local function gameDidLaunch()
 end
 gameDidLaunch()
 
--- This update method is called once per frame.
+--- This update method is called once per frame.
 function playdate.update()
     -- Example code. Draw a full-screen rectangle and the frames per second
     gfx.fillRect(0, 0, 400, 240)

--- a/source/main.lua
+++ b/source/main.lua
@@ -19,7 +19,7 @@ local gfx <const> = playdate.graphics
 -- Note: This will be called exactly once. If you're looking to do something
 -- whenever the game is resumed from the background, see playdate.gameWillResume
 -- in lifecycle.lua
-function gameDidLaunch()
+local function gameDidLaunch()
     print(playdate.metadata.name .. " launched!")
 
     gfx.setBackgroundColor(gfx.kColorBlack)

--- a/source/simulator.lua
+++ b/source/simulator.lua
@@ -34,5 +34,10 @@ function playdate.debugDraw()
 
 	-- Then perform anything you'd like overlayed on the screen
 	-- playdate.graphics.drawRect(20, 20, 150, 100)
+
+	-- To show text, you need to change the draw mode. Default text is drawn as
+	-- black, which is treated as transparent in `debugDraw`
+	-- playdate.graphics.setImageDrawMode(playdate.graphics.kDrawModeFillWhite)
+	-- playdate.graphics.drawText("hello", 0, 10)
 	playdate.graphics.popContext()
 end

--- a/source/simulator.lua
+++ b/source/simulator.lua
@@ -3,14 +3,29 @@
 
 local prefix = "[Simulator] "
 
+--- Lets you act on keyboard key presses when running in the Simulator ONLY.
+--- These can be useful for adding debugging functions that can be enabled
+--- via your keyboard.
+---
+--- @param key string The character pressed on the keyboard, if unused by the Simulator.
 function playdate.keyPressed(key)
 	print(prefix .. string.format("Pressed %s key", key))
 end
 
+--- Lets you act on keyboard key releases when running in the Simulator ONLY.
+--- These can be useful for adding debugging functions that can be enabled
+--- via your keyboard.
+---
+--- @param key string The character released on the keyboard, if unused by the Simulator.
 function playdate.keyReleased(key)
 	print(prefix .. string.format("Released %s key", key))
 end
 
+--- Called immediately after `playdate.update()`, any drawing performed during
+--- this callback is overlaid on the display in 50% transparent red (or another
+--- color selected with `playdate.setDebugDrawColor()`).
+---
+--- White pixels are drawn in the debugDrawColor. Black pixels are transparent.
 function playdate.debugDraw()
 	playdate.graphics.pushContext()
 	-- Change the color of all our debug drawing. Default is red

--- a/source/simulator.lua
+++ b/source/simulator.lua
@@ -1,7 +1,7 @@
 -- This file contains methods that are only called when running in the Simulator.
 -- See https://sdk.play.date/1.9.1/#_simulator_debug_callbacks for more information
 
-local prefix = "[Simulator] "
+local prefix <const> = "[Simulator] "
 
 --- Lets you act on keyboard key presses when running in the Simulator ONLY.
 --- These can be useful for adding debugging functions that can be enabled


### PR DESCRIPTION
This tidies up quite a few of the comments, and adds support for listing.

- Adds comments to each of the implemented callback methods
- Added comments are in EmmyLua annotation
- Old links to v1.9.0 of the docs have been updated to v1.9.1

# For Nova users
Adds a `.luacheckrc` file to configure luacheck. This works especially well with the [Luacheck extension](nova://extension/?id=pro.albright.luacheck&name=Luacheck) for Nova.
- Luacheck extension: `nova://extension/?id=pro.albright.luacheck&name=Luacheck`

# For VSCode users
Added `.vscode/settings.json` for that allowed a few global variables that are provided by the PlaydateSDK. This works especially well with the [Lua Language Server extension](https://marketplace.visualstudio.com/items?itemName=sumneko.lua) for VSCode.