### PR TITLE
Update luacheck to default to standard Lua 5.4 rules

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,10 +1,8 @@
-std = {
-    globals = {
-        "playdate"
-    },
-    read_globals = {
-        "import",
-        "print",
-        "string"
-    }
+std = "lua54"
+globals = {
+    "playdate",
+    "game"
+}
+read_globals = {
+    "import"
 }


### PR DESCRIPTION
Luacheck now correctly identifies things like "print" and "math" as part of the standard lua library.